### PR TITLE
feat: add base path router support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,34 @@ Start the server:
 python -m vibevoice_api.server --model_path vibevoice/VibeVoice-1.5B --port 8000
 ```
 
+#### API base path (`/v1` default)
+
+All routes are mounted on `/v1` by default. Override the prefix before launching the server by setting `VIBEVOICE_API_BASE_PATH` (leading slash required):
+
+```bash
+export VIBEVOICE_API_BASE_PATH=/api
+python -m vibevoice_api.server --model_path vibevoice/VibeVoice-1.5B --port 8000
+```
+
+Clients must include the same prefix when constructing URLs:
+
+```python
+base_path = "/api"  # matches VIBEVOICE_API_BASE_PATH
+client = OpenAI(base_url=f"http://127.0.0.1:8000{base_path}", api_key="<YOUR_API_KEY>")
+```
+
+The static console is served at `<base_path>/web/console.html`. Legacy root routes (e.g., `/audio/speech`, `/metrics`) remain for backwards compatibility, but new integrations should prefer the explicit prefix.
+
 Then test with either the official openai client (pip) or a pure-HTTP script.
 
 Option A — official openai (pip install openai ≥ 1.40):
 
 ```python
 from openai import OpenAI
-client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="<YOUR_API_KEY>")
+client = OpenAI(
+    base_url="http://127.0.0.1:8000/v1",  # adjust if VIBEVOICE_API_BASE_PATH changes
+    api_key="<YOUR_API_KEY>",
+)
 
 speech = client.audio.speech.create(
     model="vibevoice/VibeVoice-1.5B",  # or local path
@@ -105,6 +126,7 @@ python scripts/api_audio_speech_test.py \
 ```
 
 Notes:
+- Base URL: if you override `VIBEVOICE_API_BASE_PATH`, point clients (`base_url`, `--base_url`, browser tabs) to the same prefix (e.g., `http://127.0.0.1:8000/api`).
 - Formats: `wav` and `pcm` are native. `mp3`, `opus`, `aac` require ffmpeg. Set `VIBEVOICE_FFMPEG` to the binary path or ensure `ffmpeg` is in PATH. (flac removed)
 - `voice` handling:
   - Name mapping to `demo/voices/*.wav` (best-effort; falls back to first voice).

--- a/README_TW.md
+++ b/README_TW.md
@@ -18,13 +18,34 @@ uv pip install -e .
 python -m vibevoice_api.server --model_path "F:/VibeVoice-Large" --port 8000
 ```
 
+### API 基底路徑（預設 `/v1`）
+
+- 伺服器預設在 `/v1` 前綴下提供所有路由。若需更改，請在啟動前設定 `VIBEVOICE_API_BASE_PATH`（請包含前導斜線 `/`）：
+
+  ```bash
+  export VIBEVOICE_API_BASE_PATH=/api
+  python -m vibevoice_api.server --model_path "F:/VibeVoice-Large" --port 8000
+  ```
+
+- 客戶端請使用相同前綴建立 URL，例如：
+
+  ```python
+  base_path = "/api"  # 與 VIBEVOICE_API_BASE_PATH 相同
+  client = OpenAI(base_url=f"http://127.0.0.1:8000{base_path}", api_key="ignored")
+  ```
+
+- 靜態網頁主控台位於 `<base_path>/web/console.html`。舊的無前綴路徑仍保留相容性，但建議改用明確的前綴。
+
 3) 測試（兩種方式擇一）
 
 方式 A — 使用 OpenAI 官方套件（pip install openai ≥ 1.40）
 
 ```python
 from openai import OpenAI
-client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="ignored")
+client = OpenAI(
+    base_url="http://127.0.0.1:8000/v1",  # 若調整 VIBEVOICE_API_BASE_PATH 請同步修改
+    api_key="ignored",
+)
 
 speech = client.audio.speech.create(
     model="F:/VibeVoice-Large",
@@ -49,6 +70,7 @@ python scripts/api_audio_speech_test.py \
 ```
 ```
 
+- Base URL：若設定 `VIBEVOICE_API_BASE_PATH`，請在 openai `base_url`、腳本 `--base_url` 或瀏覽器網址中加入相同前綴（例如 `http://127.0.0.1:8000/api`）。
 - `response_format`: `wav`, `pcm` 原生；`mp3`, `opus`, `aac` 需伺服器安裝 ffmpeg（flac 已移除）。
 - `instructions`: 系統提示/風格指令，長度可由 `VIBEVOICE_INSTRUCTIONS_MAXLEN` 設定（預設 2000），超過會被截斷並在回應 `X-Hints` 顯示 `instructions_clamped`。
 


### PR DESCRIPTION
## Summary
- register FastAPI routes on a router whose prefix comes from `VIBEVOICE_API_BASE_PATH`, adjust middleware/static assets, and keep legacy root aliases
- document how to change `VIBEVOICE_API_BASE_PATH` and how clients should form URLs in both English and Traditional Chinese READMEs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d12819b21c832182ecf442346a81e4