### PR TITLE
feat(api): auto-map directories from voice map

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,17 @@ Notes:
 - Formats: `wav` and `pcm` are native. `mp3`, `opus`, `aac` require ffmpeg. Set `VIBEVOICE_FFMPEG` to the binary path or ensure `ffmpeg` is in PATH. (flac removed)
 - `voice` handling:
   - Name mapping to `demo/voices/*.wav` (best-effort; falls back to first voice).
-  - Optional YAML mapping: create `voice_map.yaml` (or set `VIBEVOICE_VOICE_MAP=path/to/voice_map.yaml`) to alias names to existing samples or custom files.
+  - Optional YAML mapping: create `voice_map.yaml` (or set `VIBEVOICE_VOICE_MAP=path/to/voice_map.yaml`) to alias names to existing samples, custom files, or whole directories that are scanned for audio files.
     Example:
-    
+
     ```yaml
     # voice_map.yaml
     alloy: en-Frank_man        # map to scanned name
     ash: demo/voices/en-Carter_man.wav  # map to explicit path
     aliases:
       shimmer: en-Alice_woman
+    directories:
+      - demo/custom_voices
     ```
   - SSE streaming: set `stream_format="sse"` to receive SSE events with base64-encoded PCM chunks.
   - Absolute/relative file path also works: set `voice="path:/abs/or/relative.wav"` or just `voice="/abs/or/relative.wav"`.
@@ -297,7 +299,7 @@ Copy the sample and edit:
 cp config/voice_map.yaml.sample config/voice_map.yaml
 ```
 
-Example mapping:
+Example mapping (aliases plus directory auto-discovery):
 
 ```yaml
 # voice_map.yaml
@@ -307,6 +309,12 @@ ash: en-Carter_man
 aliases:
   promo_female: demo/voices/en-Alice_woman.wav
   win_custom: F:\\voices\\my_voice.wav
+
+directories:
+  - demo/custom_voices
+  - path: demo/more_voices
+    prefix: promo_
+    recursive: true
 ```
 
 Then call with `voice="alloy"` (or any alias you created). Changes are picked up on next request.

--- a/README_TW.md
+++ b/README_TW.md
@@ -85,7 +85,7 @@ node scripts/js/openai_sse_client.mjs   --base http://127.0.0.1:8000   --model "
 ## 參考音檔與 voice 設定
 
 - voice 名稱（掃描 demo/voices）：預設會掃描 `demo/voices/*.wav`，並可用名稱（例如 `en-Alice_woman`）。
-- voice YAML 映射：可用 YAML 管理別名（見下一節）。
+- voice YAML 映射：可用 YAML 管理別名或自動掃描多個資料夾（見下一節）。
 - 明確路徑：用 `extra_body={"voice_path": "./my_ref.wav"}`。
 - 上傳音檔：用 `extra_body={"voice_data": "data:audio/wav;base64,..."}` 或純 base64 字串。
 
@@ -103,7 +103,7 @@ node scripts/js/openai_sse_client.mjs   --base http://127.0.0.1:8000   --model "
 cp config/voice_map.yaml.sample config/voice_map.yaml
 ```
 
-編輯 `voice_map.yaml`：
+編輯 `voice_map.yaml`（可同時設定別名與資料夾掃描）：
 
 ```yaml
 # 將常見名稱對應到掃描到的聲音名稱
@@ -114,9 +114,16 @@ ash: en-Carter_man
 aliases:
   promo_female: demo/voices/en-Alice_woman.wav
   win_custom: F:\voices\my_voice.wav
+
+# directories 區塊：列出資料夾即可依檔名自動建立 alias
+directories:
+  - demo/custom_voices
+  - path: demo/more_voices
+    prefix: promo_
+    recursive: true
 ```
 
-呼叫時直接使用 `voice="alloy"` 或 `voice="promo_female"` 即可。
+呼叫時直接使用 `voice="alloy"`、`voice="promo_female"` 或 `voice="promo_en-Miles"`（依實際檔名）即可。
 
 ## SSE 串流（text/event-stream）
 

--- a/config/voice_map.yaml.sample
+++ b/config/voice_map.yaml.sample
@@ -59,6 +59,23 @@ aliases:
   mellow: en-Maya_woman
 
 
+# -------- directories: auto-discover voices from folders --------
+# You can list directories and the server will create aliases from the file names
+# found inside. Extensions supported: .wav, .mp3, .flac, .ogg, .opus, .aac, .m4a
+directories:
+  # 1) Simple relative directory (non-recursive). File demo/custom/en-Joy.wav
+  #     becomes alias "en-Joy" plus normalized variants.
+  - demo/custom
+
+  # 2) Directory with prefix and recursion. Files under demo/more_voices/**
+  #     become aliases like "promo_en-Miles". Set normalize: true if you also
+  #     want relaxed variants (e.g., "en-Miles").
+  - path: demo/more_voices
+    prefix: promo_
+    recursive: true
+    # normalize: true
+
+
 # Notes
 # -----
 # - Aliases override internal auto aliases if duplicated.

--- a/tests/vibevoice_api/test_voice_map.py
+++ b/tests/vibevoice_api/test_voice_map.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+
+from vibevoice_api.voice_map import VoiceMapper
+
+
+def _touch(path: os.PathLike[str] | str) -> None:
+    with open(path, "wb") as f:
+        f.write(b"voice")
+
+
+def test_voice_map_directories_and_prefixes(tmp_path) -> None:
+    root = tmp_path
+
+    demo_dir = root / "demo" / "voices"
+    demo_dir.mkdir(parents=True)
+    _touch(demo_dir / "base.wav")
+
+    custom_dir = root / "custom_dir"
+    custom_dir.mkdir()
+    _touch(custom_dir / "hero.wav")
+
+    nested_dir = root / "more" / "nested"
+    nested_dir.mkdir(parents=True)
+    _touch(nested_dir / "beta.wav")
+
+    alt_dir = root / "more_exact"
+    alt_dir.mkdir()
+    _touch(alt_dir / "gamma.wav")
+
+    (root / "voice_map.yaml").write_text(
+        "\n".join(
+            [
+                "aliases:",
+                "  alias_base: base",
+                "directories:",
+                "  - custom_dir",
+                "  - path: more",
+                "    prefix: promo_",
+                "    recursive: true",
+                "  - path: more_exact",
+                "    prefix: alt_",
+                "    normalize: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    mapper = VoiceMapper(str(root))
+    available = mapper.available()
+
+    assert available["hero"] == str(custom_dir / "hero.wav")
+    assert available["promo_beta"] == str(nested_dir / "beta.wav")
+    assert "beta" not in available
+    assert available["alt_gamma"] == str(alt_dir / "gamma.wav")
+    assert available["gamma"] == str(alt_dir / "gamma.wav")
+    assert mapper.resolve("alias_base") == str(demo_dir / "base.wav")


### PR DESCRIPTION
## Summary
- allow `voice_map.yaml` entries to point at directories that are scanned for audio files
- document the new directory syntax in the README files and sample voice-map config
- cover directory loading behaviour with a dedicated unit test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1254aaa188321841364cf18eac241